### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -24,4 +24,4 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances.
 Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident.
 
-This Code of Conduct is adapted from the http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].
+This Code of Conduct is adapted from the https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/].

--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,7 @@ are often ingested into application monitoring tools where they can be further p
 dashboards of an application's performance.  
 
 Most important for Spring Cloud Data Flow Stream applications are the inclusion of 
-http://docs.spring.io/spring-integration/reference/html/system-management-chapter.html#mgmt-channel-features[Spring Integration channel metrics] such as message rates.
+https://docs.spring.io/spring-integration/reference/html/system-management-chapter.html#mgmt-channel-features[Spring Integration channel metrics] such as message rates.
 
 == Maven configuration
 
@@ -29,7 +29,7 @@ and reference the Spring Snapshot repository
 <repository>
   <id>spring-libs-snapshot</id>
   <name>Spring Snapshot Repository</name>
-  <url>http://repo.spring.io/libs-snapshot</url>
+  <url>https://repo.spring.io/libs-snapshot</url>
 </repository>
 ----
 
@@ -55,7 +55,7 @@ Other useful property placeholder keys that you should be aware of when setting 
 * `${spring.cloud.client.ipAddress}`
 * `${spring.cloud.client.hostname}`
 
-The exporting process is controller though https://github.com/spring-projects/spring-boot/blob/master/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/MetricExportProperties.java[MetricExportProperties]. This lets you control how often the metrics are exported and which metrics to include/exclude.  Some documentation is available http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metric-writers[here].
+The exporting process is controller though https://github.com/spring-projects/spring-boot/blob/master/spring-boot-actuator/src/main/java/org/springframework/boot/actuate/metrics/export/MetricExportProperties.java[MetricExportProperties]. This lets you control how often the metrics are exported and which metrics to include/exclude.  Some documentation is available https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-metric-writers[here].
 
 == Sister projects
 
@@ -63,7 +63,7 @@ The project https://github.com/spring-cloud/spring-cloud-dataflow-metrics-datado
 
 == Sample application
 
-https://github.com/markpollack/timemonitor[Timemonitor] is an example application (a WIP) that demonstrates creating the time source application from http://start-scs.cfapps.io/[Data Flow App Starters] and adding the ability to export metrics.
+https://github.com/markpollack/timemonitor[Timemonitor] is an example application (a WIP) that demonstrates creating the time source application from https://start-scs.cfapps.io/[Data Flow App Starters] and adding the ability to export metrics.
 
 == Release Plans
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-integration/reference/html/system-management-chapter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference/html/system-management-chapter.html ([https](https://docs.spring.io/spring-integration/reference/html/system-management-chapter.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/ ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/) result 200).
* [ ] http://start-scs.cfapps.io/ with 1 occurrences migrated to:  
  https://start-scs.cfapps.io/ ([https](https://start-scs.cfapps.io/) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://repo.spring.io/libs-snapshot with 1 occurrences migrated to:  
  https://repo.spring.io/libs-snapshot ([https](https://repo.spring.io/libs-snapshot) result 302).